### PR TITLE
chore: avoid installing dependencies with prefix

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
### MONOREPO CHANGES

---

- Add npmrc to avoid installing dependencies with prefix
